### PR TITLE
add ability to output information in json

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Summary
 Body
 ```
 
+also tiramisu can output information in json so it can be easily parsed.
+
 If any specific setting is disabled in the configuration, the line is omitted
 from the output (making all of the output one line shorter).
 

--- a/config.h
+++ b/config.h
@@ -2,4 +2,5 @@
 // #define RECEIVE_APP_ICON
 // #define RECEIVE_REPLACES_ID
 // #define RECEIVE_EXPIRE_TIMEOUT
+#define PRINT_JSON
 #define OUTPUT_DELIMITER "\n"

--- a/format.c
+++ b/format.c
@@ -3,6 +3,17 @@
 #include "config.h"
 #include "format.h"
 
+void escape_quotes(char *str, char *out) {
+    memset(out, 0, strlen(out));
+    while (*str) {
+        if (*str == '"')
+            strcat(out, "\\\"");
+        else
+            out[strlen(out)] = *str;
+        str++;
+    }
+}
+
 void output_notification(gchar *app_name, guint32 replaces_id, gchar *app_icon,
     gchar *summary, gchar *body, GVariant *actions, GVariant *hints,
     gint32 timeout) {
@@ -28,17 +39,24 @@ void output_notification(gchar *app_name, guint32 replaces_id, gchar *app_icon,
     sprintf(string, "%s%s%d%s%s%s%s", string, OUTPUT_DELIMITER,
         timeout, OUTPUT_DELIMITER, summary, OUTPUT_DELIMITER, body);
 #else
-    sprintf(string, "{ \"app_name\": \"%s\"", app_name);
+    char *escaped_str = (char *)calloc(512, sizeof(char));
+    escape_quotes(app_name, escaped_str);
+    sprintf(string, "{ \"app_name\": \"%s\"", escaped_str);
 
 #ifdef RECEIVE_APP_ICON
-    sprintf(string, "%s, \"app_icon\": \"%s\"", string, app_icon);
+    escape_quotes(app_icon, escaped_str);
+    sprintf(string, "%s, \"app_icon\": \"%s\"", string, escaped_str);
 #endif
 
 #ifdef RECEIVE_REPLACES_ID
     sprintf(string, "%s, \"replaces_id\": %lu", string, replaces_id);
 #endif
 
-    sprintf(string, "%s, \"timeout\": %d, \"summary\": \"%s\", \"body\": \"%s\" }", string, timeout, summary, body);
+    escape_quotes(summary, escaped_str);
+    sprintf(string, "%s, \"timeout\": %d, \"summary\": \"%s\"", string, timeout, escaped_str);
+
+    escape_quotes(body, escaped_str);
+    sprintf(string, "%s, \"body\": \"%s\" }", string, escaped_str);
 
 #endif
 
@@ -46,4 +64,5 @@ void output_notification(gchar *app_name, guint32 replaces_id, gchar *app_icon,
     fflush(stdout);
 
     free(string);
+    free(escaped_str);
 }

--- a/format.c
+++ b/format.c
@@ -3,7 +3,7 @@
 #include "config.h"
 #include "format.h"
 
-void escape_quotes(char *str, char *out) {
+char* escape_quotes(char *str, char *out) {
     memset(out, 0, strlen(out));
     while (*str) {
         if (*str == '"')
@@ -12,6 +12,8 @@ void escape_quotes(char *str, char *out) {
             out[strlen(out)] = *str;
         str++;
     }
+
+    return out;
 }
 
 void output_notification(gchar *app_name, guint32 replaces_id, gchar *app_icon,
@@ -40,23 +42,23 @@ void output_notification(gchar *app_name, guint32 replaces_id, gchar *app_icon,
         timeout, OUTPUT_DELIMITER, summary, OUTPUT_DELIMITER, body);
 #else
     char *escaped_str = (char *)calloc(512, sizeof(char));
-    escape_quotes(app_name, escaped_str);
-    sprintf(string, "{ \"app_name\": \"%s\"", escaped_str);
+
+    sprintf(string, "{ \"app_name\": \"%s\"", escape_quotes(app_name, escaped_str));
 
 #ifdef RECEIVE_APP_ICON
-    escape_quotes(app_icon, escaped_str);
-    sprintf(string, "%s, \"app_icon\": \"%s\"", string, escaped_str);
+    sprintf(string, "%s, \"app_icon\": \"%s\"", string, escape_quotes(app_icon, escaped_str));
 #endif
+
+    /* TODO: actions */
+    /* TODO: hints */
 
 #ifdef RECEIVE_REPLACES_ID
     sprintf(string, "%s, \"replaces_id\": %lu", string, replaces_id);
 #endif
 
-    escape_quotes(summary, escaped_str);
-    sprintf(string, "%s, \"timeout\": %d, \"summary\": \"%s\"", string, timeout, escaped_str);
+    sprintf(string, "%s, \"timeout\": %d, \"summary\": \"%s\"", string, timeout, escape_quotes(summary, escaped_str));
 
-    escape_quotes(body, escaped_str);
-    sprintf(string, "%s, \"body\": \"%s\" }", string, escaped_str);
+    sprintf(string, "%s, \"body\": \"%s\" }", string, escape_quotes(body, escaped_str));
 
 #endif
 

--- a/format.c
+++ b/format.c
@@ -11,6 +11,7 @@ void output_notification(gchar *app_name, guint32 replaces_id, gchar *app_icon,
     /* 2048 characters should be significantly long enough*/
     char *string = (char *)calloc(2048, sizeof(char));
 
+#ifndef PRINT_JSON
     strcat(string, app_name);
 
 #ifdef RECEIVE_APP_ICON
@@ -26,6 +27,20 @@ void output_notification(gchar *app_name, guint32 replaces_id, gchar *app_icon,
 
     sprintf(string, "%s%s%d%s%s%s%s", string, OUTPUT_DELIMITER,
         timeout, OUTPUT_DELIMITER, summary, OUTPUT_DELIMITER, body);
+#else
+    sprintf(string, "{ \"app_name\": \"%s\"", app_name);
+
+#ifdef RECEIVE_APP_ICON
+    sprintf(string, "%s, \"app_icon\": \"%s\"", string, app_icon);
+#endif
+
+#ifdef RECEIVE_REPLACES_ID
+    sprintf(string, "%s, \"replaces_id\": %lu", string, replaces_id);
+#endif
+
+    sprintf(string, "%s, \"timeout\": %d, \"summary\": \"%s\", \"body\": \"%s\" }", string, timeout, summary, body);
+
+#endif
 
     printf("%s\n", string);
     fflush(stdout);


### PR DESCRIPTION
If information will be printed as a plain text there is a chanse that the notification would have delimiter where it shouldn't be.
But if information is printed as a json user can be sure that output won't be corrupted with delimiters and also json can be easily parsed with something like `jq`. :D