### PR TITLE
make: Allow passing LDFLAGS environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LFLAGS	=	$(shell pkg-config --libs glib-2.0 gio-2.0)
 all: $(TARGET)
 
 $(TARGET): $(OBJ)
-	$(CC) $(CFLAGS) $(IFLAGS) $(SRC) $(LFLAGS) -o $(TARGET)
+	$(CC) $(CFLAGS) $(LDFLAGS) $(IFLAGS) $(SRC) $(LFLAGS) -o $(TARGET)
 
 install: $(TARGET)
 	mkdir -p $(DESTDIR)$(PREFIX)/bin


### PR DESCRIPTION
Arch Linux for example passes `-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now`. The options `-Wl,-z,now` enable Full [RELRO][1] for better security.

[1]: https://wiki.archlinux.org/index.php/Arch_package_guidelines/Security#RELRO