### PR TITLE
Always add a newline after "hints:" and "actions:" when not using PRI…

### DIFF
--- a/callbacks.c
+++ b/callbacks.c
@@ -90,7 +90,7 @@ output:
 #ifdef PRINT_JSON
     printf("\"hints\": { ");
 #else
-    printf("hints: ");
+    printf("hints:\n");
 #endif
 
     gchar *key;
@@ -172,7 +172,7 @@ output:
 #ifdef PRINT_JSON
     printf("}, \"actions\": {");
 #else
-    printf("actions: ");
+    printf("actions:\n");
 #endif
 
     while (actions[index] && actions[index + 1]) {


### PR DESCRIPTION
…NT_JSON mode

This way, the next line is not fused with the hints and actions line,
when the is no hint or action.

Before this commit with action "foo: bar" and summary "baz":
```
actions:	foo: baz
summary: baz
```

After this commit:
```
actions:
	foo: baz
summary: baz
```

Before this commit without action and summary "baz":
```
actions: summary: baz
```

After this commit:
```
actions:
summary: baz
```

Fixes #14.