### PR TITLE
Ignore unsupported hints. (fixes issue with stray commas in JSON output)

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -115,6 +115,8 @@ void hints_output_iterator(GVariant *hints, const char *str_format,
         /* Booleans */
         else if ((value = g_variant_lookup_value(hints, key, GT_BOOL)))
             printf(boolean_format, key, g_variant_get_boolean(value));
+        else
+            continue;
 
         g_variant_unref(value);
         index++;


### PR DESCRIPTION
The JSON output sometimes has extra commas when a hint with an unsupported type is recieved. This only affects the "image-data", "image_data" and "icon_data" hints, but printing them as text doesn't really make sense. I guess it's best to ignore them for now?