### PR TITLE
Add unknown type formatter to hints_output_iterator()

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -165,6 +165,7 @@ void default_output(gchar *app_name, gchar *app_icon, guint32 replaces_id,
     free(double_format);
     free(boolean_format);
     free(byte_format);
+    free(err_format);
 
     printf("actions:%s", delimiter);
 

--- a/src/output.c
+++ b/src/output.c
@@ -73,7 +73,7 @@ void hints_output_iterator(GVariant *hints, const char *str_format,
     const char *int_format, const char *uint_format,
     const char *double_format, const char *boolean_format,
     const char *byte_format, const char *err_format,
-	const char *element_delimiter) {
+    const char *element_delimiter) {
 
     GVariantIter iterator;
     gchar *key;
@@ -116,11 +116,11 @@ void hints_output_iterator(GVariant *hints, const char *str_format,
         else if ((value = g_variant_lookup_value(hints, key, GT_BOOL)))
             printf(boolean_format, key, g_variant_get_boolean(value));
         else {
-			// value is of unknown type
-			printf(err_format, key);
-			index++;
+            // value is of unknown type
+            printf(err_format, key);
+            index++;
             continue;
-		}
+        }
 
         g_variant_unref(value);
         index++;

--- a/src/output.c
+++ b/src/output.c
@@ -72,7 +72,8 @@ void output_notification(GVariant *parameters) {
 void hints_output_iterator(GVariant *hints, const char *str_format,
     const char *int_format, const char *uint_format,
     const char *double_format, const char *boolean_format,
-    const char *byte_format, const char *element_delimiter) {
+    const char *byte_format, const char *err_format,
+	const char *element_delimiter) {
 
     GVariantIter iterator;
     gchar *key;
@@ -85,7 +86,6 @@ void hints_output_iterator(GVariant *hints, const char *str_format,
     while (g_variant_iter_loop(&iterator, "{sv}", &key, NULL)) {
         if (index)
             printf(element_delimiter);
-
         /* Strings */
         if ((value = g_variant_lookup_value(hints, key, GT_STRING))) {
             value_sanitized = sanitize(g_variant_get_string(value, NULL));
@@ -115,8 +115,12 @@ void hints_output_iterator(GVariant *hints, const char *str_format,
         /* Booleans */
         else if ((value = g_variant_lookup_value(hints, key, GT_BOOL)))
             printf(boolean_format, key, g_variant_get_boolean(value));
-        else
+        else {
+			// value is of unknown type
+			printf(err_format, key);
+			index++;
             continue;
+		}
 
         g_variant_unref(value);
         index++;
@@ -140,7 +144,8 @@ void default_output(gchar *app_name, gchar *app_icon, guint32 replaces_id,
         *uint_format    = calloc(64, sizeof(char)),
         *double_format  = calloc(64, sizeof(char)),
         *boolean_format = calloc(64, sizeof(char)),
-        *byte_format    = calloc(64, sizeof(char));
+        *byte_format    = calloc(64, sizeof(char)),
+        *err_format     = calloc(64, sizeof(char));
 
     sprintf(str_format,     "\t%%s: %%s%s", delimiter);
     sprintf(int_format,     "\t%%s: %%d%s", delimiter);
@@ -148,10 +153,11 @@ void default_output(gchar *app_name, gchar *app_icon, guint32 replaces_id,
     sprintf(double_format,  "\t%%s: %%f%s", delimiter);
     sprintf(boolean_format, "\t%%s: %%x%s", delimiter);
     sprintf(byte_format,    "\t%%s: %%d%s", delimiter);
+    sprintf(err_format,     "\t%%s:%s", delimiter);
 
     hints_output_iterator(hints,
         str_format, int_format, uint_format, double_format, boolean_format,
-        byte_format, "");
+        byte_format, err_format, "");
 
     free(str_format);
     free(int_format);
@@ -186,7 +192,7 @@ void json_output(gchar *app_name, gchar *app_icon, guint32 replaces_id,
 
     printf("\"hints\": {");
     hints_output_iterator(hints, "\"%s\": \"%s\"", "\"%s\": %d", "\"%s\": %u",
-        "\"%s\": %f", "\"%s\": %x", "\"%s\": %d", ", ");
+        "\"%s\": %f", "\"%s\": %x", "\"%s\": %d", "\"%s\": \"\"", ", ");
     printf("}, \"actions\": {");
 
     unsigned int index = 0;

--- a/src/output.h
+++ b/src/output.h
@@ -18,7 +18,7 @@ char *sanitize(const char*);
 
 void output_notification(GVariant*);
 void hints_output_iterator(GVariant*, const char*, const char*, const char*,
-    const char*, const char*, const char*, const char*);
+    const char*, const char*, const char*, const char*, const char*);
 void default_output(gchar*, gchar*, guint32, gint32, GVariant*, gchar**, gchar*,
     gchar*);
 void json_output(gchar*, gchar*, guint32, gint32, GVariant*, gchar**, gchar*,


### PR DESCRIPTION
This resolves #18.

Commit message c3ba4d1:

The hints_output_iterator() function skips a hint if its value is not of any of the types explicitly checked for in the if-else chain. However, it prints a comma before this check, meaning values of unknown type result in a trailing comma. By adding a formatter for such values, we not only resolve the trailing comma issue, but also let the user know that their notification contained a hint of an unknown type, rather than hiding it.