### PR TITLE
Makefile: use standard syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
-
 TARGET	=	tiramisu
-SRC		:=	src/tiramisu.c src/events.c src/notification.c
+SRC	:=	src/tiramisu.c src/events.c src/notification.c
 
-PREFIX ?=	/usr/local
-INSTALL =   install -Dm755
+PREFIX	?=	/usr/local
+INSTALL	=	install -Dm755
+RM	?=	rm -f
 
-CFLAGS +=	-Wall -Wno-unused-value
-IFLAGS  =	$(shell pkg-config --cflags glib-2.0 gio-2.0)
-LFLAGS	=	$(shell pkg-config --libs glib-2.0 gio-2.0)
+CFLAGS	+=	-Wall -Wno-unused-value
+IFLAGS	=	`pkg-config --cflags glib-2.0 gio-2.0`
+LFLAGS	=	`pkg-config --libs glib-2.0 gio-2.0`
 
 all: $(TARGET)
 


### PR DESCRIPTION
$(RM) isn't set by default in BSD make so clean doesn't work properly.
The `$(shell <command>)` syntax doesn't work either so it is replaced with `` `<command>` `` which does the exact same thing

(edit: markdown)