### PR TITLE
Don't force VALAC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
-TARGET	=	tiramisu
-SRC		:=	src/notification.vala src/dbus.vala src/tiramisu.vala
+TARGET   = tiramisu
+SRC     := src/notification.vala src/dbus.vala src/tiramisu.vala
 
-PREFIX	?=	/usr/local
-INSTALL	=	install -Dm755
-RM	?=	rm -f
+PREFIX  ?= /usr/local
+INSTALL  = install -Dm755
+RM      ?= rm -f
 
-VALAC		= 	valac
-CFLAGS	+=	-Wall -Wno-unused-value
-IFLAGS	=	--pkg gio-2.0
-LFLAGS	=	`pkg-config --libs glib-2.0 gio-2.0`
+VALAC   ?= valac
+CFLAGS  += -Wall -Wno-unused-value
+IFLAGS   = --pkg gio-2.0
+LFLAGS   = `pkg-config --libs glib-2.0 gio-2.0`
 
 all: $(TARGET)
 


### PR DESCRIPTION
Some distros (Gentoo) don't have unversioned binaries for valac